### PR TITLE
Handle data types besides strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,5 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         ],
+    install_requires = ['simplejson'],
     )


### PR DESCRIPTION
So far we assumed hiera outputs only strings but yaml also handles lists
and dicts. Unparsing this from the returned string is cumbersome so use
hiera's relatively new --format option instead. We use JSON instead of
YAML since the YAML part is even newer.
